### PR TITLE
Fix invalid octal literal in DAG start_date

### DIFF
--- a/dags/ML_Data_ETL_dag.py
+++ b/dags/ML_Data_ETL_dag.py
@@ -33,7 +33,7 @@ with DAG(
     default_args=default_args,
     description="Fetch weather data and insert into PostgreSQL",
     schedule_interval="0 23 * * *",
-    start_date=datetime(2025, 01, 04),
+    start_date=datetime(2025, 1, 4),
     catchup=False,
 ) as dag:
     # -----------------------------------------------------------------


### PR DESCRIPTION
Python 3 does not allow leading zeros in decimal integer literals, so datetime(2025, 01, 04) raised a SyntaxError and the DAG never loaded in Airflow.

Fixes #11