### PR TITLE
Request weather data in metric units

### DIFF
--- a/dags/ML_Data_ETL_dag.py
+++ b/dags/ML_Data_ETL_dag.py
@@ -78,7 +78,12 @@ with DAG(
             try:
                 response = requests.get(
                     base_url,
-                    params={"lat": lat, "lon": lon, "appid": api_key},
+                    params={
+                        "lat": lat,
+                        "lon": lon,
+                        "appid": api_key,
+                        "units": "metric",
+                    },
                     timeout=10,  # optional: set a timeout for requests
                 )
                 if response.status_code == 200:


### PR DESCRIPTION
The OpenWeather current weather endpoint returns Kelvin unless units is supplied, so the temperature column was being populated with values like 291.15 while the docs describe Celsius.

Fixes #13