### PR TITLE
Use schedule instead of deprecated schedule_interval

### DIFF
--- a/dags/ML_Data_ETL_dag.py
+++ b/dags/ML_Data_ETL_dag.py
@@ -32,7 +32,7 @@ with DAG(
     dag_id="weather_data_pipeline",
     default_args=default_args,
     description="Fetch weather data and insert into PostgreSQL",
-    schedule_interval="0 23 * * *",
+    schedule="0 23 * * *",
     start_date=datetime(2025, 1, 4),
     catchup=False,
 ) as dag:


### PR DESCRIPTION
schedule_interval has been deprecated since Airflow 2.4 and was removed in Airflow 3. Renaming keeps the example working on current and future Airflow releases.

Fixes #15