### PR TITLE
Add docker-compose for one-command local setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,13 @@
+# Copy this file to .env before starting the stack:
+#
+#   cp .env.example .env
+#
+# .env is git-ignored, so your real values never leave your machine.
+
+# Free OpenWeather API key: https://home.openweathermap.org/api_keys
+OPENWEATHER_API_KEY=replace_me
+
+# Credentials for the Airflow web UI, created by the airflow-init service.
+# Development defaults - change them for anything beyond local use.
+AIRFLOW_ADMIN_USERNAME=airflow
+AIRFLOW_ADMIN_PASSWORD=airflow

--- a/README.md
+++ b/README.md
@@ -25,6 +25,15 @@ pytest tests -q
 
 Then work through the [Setup Instructions](#setup-instructions) to configure Airflow, PostgreSQL and a free OpenWeather API key, and trigger `weather_data_pipeline` from the Airflow UI.
 
+### Run the whole stack with Docker
+
+```bash
+cp .env.example .env    # add your free OpenWeather API key
+docker compose up
+```
+
+Airflow is then available at http://localhost:8080 (default login `airflow` / `airflow`) with `weather_data_pipeline` already registered and both connections pre-configured. Prefer to install everything yourself? Follow the [Setup Instructions](#setup-instructions) below.
+
 ## Table of Contents
 - [Quickstart](#quickstart)
 - [Overview](#overview)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,78 @@
+# Minimal local stack for AirFlow-ML-Data-Integration.
+#
+#   cp .env.example .env      # then add your OpenWeather API key
+#   docker compose up
+#
+# Airflow UI: http://localhost:8080
+
+x-airflow-common: &airflow-common
+  image: apache/airflow:2.10.4-python3.11
+  environment:
+    AIRFLOW__CORE__EXECUTOR: LocalExecutor
+    AIRFLOW__CORE__LOAD_EXAMPLES: "false"
+    AIRFLOW__DATABASE__SQL_ALCHEMY_CONN: postgresql+psycopg2://airflow:airflow@postgres:5432/airflow
+    AIRFLOW_CONN_POSTGRES_WEATHER_DB: postgresql://airflow:airflow@postgres:5432/weather
+    AIRFLOW_CONN_OPENWEATHER_API_KEY: >-
+      {"conn_type": "http",
+       "host": "https://api.openweathermap.org/data/2.5/weather",
+       "extra": {"api_key": "${OPENWEATHER_API_KEY}"}}
+    _PIP_ADDITIONAL_REQUIREMENTS: apache-airflow-providers-postgres pandas requests
+  volumes:
+    - ./dags:/opt/airflow/dags
+    - airflow-logs:/opt/airflow/logs
+
+services:
+  postgres:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: airflow
+      POSTGRES_PASSWORD: airflow
+      POSTGRES_DB: airflow
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+      - ./docker/init-weather-db.sql:/docker-entrypoint-initdb.d/init-weather-db.sql:ro
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U airflow"]
+      interval: 5s
+      retries: 10
+    ports:
+      - "5432:5432"
+
+  airflow-init:
+    <<: *airflow-common
+    depends_on:
+      postgres:
+        condition: service_healthy
+    entrypoint: /bin/bash
+    command:
+      - -c
+      - |
+        airflow db migrate
+        airflow users create \
+          --username "${AIRFLOW_ADMIN_USERNAME:-airflow}" \
+          --password "${AIRFLOW_ADMIN_PASSWORD:-airflow}" \
+          --firstname Air --lastname Flow \
+          --role Admin --email airflow@example.com
+    restart: on-failure
+
+  airflow-scheduler:
+    <<: *airflow-common
+    command: scheduler
+    restart: unless-stopped
+    depends_on:
+      airflow-init:
+        condition: service_completed_successfully
+
+  airflow-webserver:
+    <<: *airflow-common
+    command: webserver
+    ports:
+      - "8080:8080"
+    restart: unless-stopped
+    depends_on:
+      airflow-init:
+        condition: service_completed_successfully
+
+volumes:
+  postgres-data:
+  airflow-logs:

--- a/docker/init-weather-db.sql
+++ b/docker/init-weather-db.sql
@@ -1,0 +1,18 @@
+-- Runs automatically the first time the postgres container starts.
+-- Creates the weather database and the table written to by insert_weather_data.
+
+CREATE DATABASE weather;
+
+\connect weather
+
+CREATE TABLE IF NOT EXISTS weather (
+    id SERIAL PRIMARY KEY,
+    city VARCHAR(100) NOT NULL,
+    date DATE NOT NULL,
+    temperature NUMERIC(6, 2),
+    humidity INTEGER,
+    wind_speed NUMERIC(6, 2),
+    weather_condition VARCHAR(150)
+);
+
+CREATE INDEX IF NOT EXISTS idx_weather_city_date ON weather (city, date);


### PR DESCRIPTION
Adds docker-compose.yml (Airflow init, scheduler and webserver plus PostgreSQL), a database bootstrap script, .env.example and a Docker section in the README Quickstart. Both Airflow connections are wired through environment variables, so getting the DAG running goes from six manual setup guides to two commands.

Fixes #24