### PR TITLE
Add SECURITY.md with private reporting policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,13 @@
+# Security Policy
+
+## Supported versions
+
+This is a tutorial project, so only the current `main` branch receives fixes.
+
+## Reporting a vulnerability
+
+Please do not open a public issue for a security problem. Use the private "Report a vulnerability" form under the Security tab of this repository, or contact the maintainer through the email on the GitHub profile. Expect an acknowledgement within seven days.
+
+## Scope
+
+The most likely issue in a project like this one is a leaked credential. The DAG reads its OpenWeather key from an Airflow connection or from a local `.env` file, and neither is committed. If you find a key anywhere in the history, please report it privately so it can be rotated before disclosure.


### PR DESCRIPTION
Documents supported versions, points reporters at the private advisory form instead of public issues, and calls out leaked credentials as the likely class of issue for this project.

## Summary

What does this change, and why?

## Related issue

Fixes #

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor or tooling

## Checklist

- [ ] `ruff check dags tests` passes
- [ ] `python -m compileall -q dags` passes
- [ ] `pytest tests -q` passes
- [ ] Documentation updated where relevant
- [ ] No credentials or API keys are included in the diff
