### PR TITLE
Add .gitattributes to normalise line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,15 @@
+# Normalise line endings so Windows and Linux contributors produce identical diffs.
+* text=auto eol=lf
+
+*.py text
+*.md text
+*.yml text
+*.yaml text
+*.cfg text
+*.txt text
+*.sql text
+
+*.png binary
+*.jpg binary
+*.ico binary
+*.db binary


### PR DESCRIPTION
Forces LF in the repository regardless of contributor platform and marks image and database files as binary so git stops trying to diff them. Pairs with the .editorconfig change.

## Summary

What does this change, and why?

## Related issue

Fixes #

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor or tooling

## Checklist

- [ ] `ruff check dags tests` passes
- [ ] `python -m compileall -q dags` passes
- [ ] `pytest tests -q` passes
- [ ] Documentation updated where relevant
- [ ] No credentials or API keys are included in the diff
