### PR TITLE
Add Dependabot config for pip and Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: pip
+  directory: /
+  schedule:
+    interval: weekly
+  open-pull-requests-limit: 5
+  - package-ecosystem: github-actions
+  directory: /
+  schedule:
+    interval: weekly
+  


### PR DESCRIPTION
Weekly checks against requirements.txt and the workflow action versions, capped at five open PRs so it cannot bury the queue. Airflow provider packages drift quickly, so pinned requirements go stale without something watching them.

## Summary

What does this change, and why?

## Related issue

Fixes #

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor or tooling

## Checklist

- [ ] `ruff check dags tests` passes
- [ ] `python -m compileall -q dags` passes
- [ ] `pytest tests -q` passes
- [ ] Documentation updated where relevant
- [ ] No credentials or API keys are included in the diff
